### PR TITLE
Fix Poetry Install

### DIFF
--- a/part-13-docker-deployment/backend/Dockerfile
+++ b/part-13-docker-deployment/backend/Dockerfile
@@ -17,7 +17,7 @@ ENV ENVIRONMENT prod
 ENV TESTING 0
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
[https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py](https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py) is outdated and fails with a 404.