### PR TITLE
Fix incorrect return type annotation for root function from dict to HTMLResponse

### DIFF
--- a/part-06-jinja-templates/app/main.py
+++ b/part-06-jinja-templates/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, APIRouter, Query, HTTPException, Request
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 
 from typing import Optional, Any
 from pathlib import Path
@@ -21,7 +22,7 @@ api_router = APIRouter()
 # https://www.starlette.io/templates/
 # https://jinja.palletsprojects.com/en/3.0.x/templates/#synopsis
 @api_router.get("/", status_code=200)
-def root(request: Request) -> dict:
+def root(request: Request) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-06b-basic-deploy-linode/app/main.py
+++ b/part-06b-basic-deploy-linode/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, APIRouter, Query, HTTPException, Request
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 
 from typing import Optional, Any
 from pathlib import Path
@@ -21,7 +22,7 @@ api_router = APIRouter()
 # https://www.starlette.io/templates/
 # https://jinja.palletsprojects.com/en/3.0.x/templates/#synopsis
 @api_router.get("/", status_code=200)
-def root(request: Request) -> dict:
+def root(request: Request) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-07-database/app/main.py
+++ b/part-07-database/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, APIRouter, Query, HTTPException, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 
 from typing import Optional, Any
 from pathlib import Path
@@ -28,7 +29,7 @@ api_router = APIRouter()
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-08-structure-and-versioning/app/main.py
+++ b/part-08-structure-and-versioning/app/main.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from app import crud
@@ -20,7 +21,7 @@ app = FastAPI(title="Recipe API")
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-09-async/app/main.py
+++ b/part-09-async/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from app import crud
@@ -21,7 +22,7 @@ app = FastAPI(title="Recipe API", openapi_url="/openapi.json")
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-10-jwt-auth/app/main.py
+++ b/part-10-jwt-auth/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from app import crud
@@ -21,7 +22,7 @@ app = FastAPI(title="Recipe API", openapi_url=f"{settings.API_V1_STR}/openapi.js
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-11-dependency-injection/app/main.py
+++ b/part-11-dependency-injection/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from app import crud
@@ -21,7 +22,7 @@ app = FastAPI(title="Recipe API", openapi_url=f"{settings.API_V1_STR}/openapi.js
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-12-react-frontend/backend/app/main.py
+++ b/part-12-react-frontend/backend/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -33,7 +34,7 @@ if settings.BACKEND_CORS_ORIGINS:
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-13-docker-deployment/backend/app/app/main.py
+++ b/part-13-docker-deployment/backend/app/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -33,7 +34,7 @@ if settings.BACKEND_CORS_ORIGINS:
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """

--- a/part-14-send-email-in-background/backend/app/app/main.py
+++ b/part-14-send-email-in-background/backend/app/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -35,7 +36,7 @@ if settings.BACKEND_CORS_ORIGINS:
 def root(
     request: Request,
     db: Session = Depends(deps.get_db),
-) -> dict:
+) -> HTMLResponse:
     """
     Root GET
     """


### PR DESCRIPTION
As per the [Using Jinja2Templates section](https://fastapi.tiangolo.com/advanced/templates/#using-jinja2templates) of the FastAPI advanced user guide, functions returning templates should have their return type annotated as `HTMLResponse`.